### PR TITLE
mapTeamPoints did not define self

### DIFF
--- a/helpers/teamHelper.js
+++ b/helpers/teamHelper.js
@@ -96,6 +96,7 @@ exports.mapMatchups = function(matchups) {
 };
 
 exports.mapTeamPoints = function(team, points) {
+  var self = this;
   team.points = points.team_points;
 
   if ( points.team_stats ) {


### PR DESCRIPTION
league.scoreboard results in an error because self was not defined in this function. Quick and easy fix.